### PR TITLE
Update port configuration and secure environment variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 data/
 node_modules/
 client/build/
+.env

--- a/nodemon.json
+++ b/nodemon.json
@@ -2,8 +2,5 @@
   "watch": ["server/src"],
   "ext": "ts,js,json",
   "ignore": ["server/src/**/*.spec.ts", "server/src/**/*.test.ts"],
-  "exec": "tsx server/src/server.ts",
-  "env": {
-    "PORT": "3001"
-  }
+  "exec": "tsx server/src/server.ts"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "cookie-parser": "^1.4.7",
         "date-fns": "^4.1.0",
         "debug": "^4.4.3",
+        "dotenv": "^17.2.2",
         "express": "^5.1.0",
         "mongodb": "^6.19.0",
         "morgan": "^1.10.1",
@@ -2660,6 +2661,18 @@
       "dependencies": {
         "asap": "^2.0.0",
         "wrappy": "1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "cookie-parser": "^1.4.7",
     "date-fns": "^4.1.0",
     "debug": "^4.4.3",
+    "dotenv": "^17.2.2",
     "express": "^5.1.0",
     "mongodb": "^6.19.0",
     "morgan": "^1.10.1",

--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import * as path from 'path';
 import { AppConfig } from '../../../types/models';
 
@@ -8,11 +9,11 @@ const config: AppConfig = {
   strava: {
     authProvider: {
       authUrl: 'https://www.strava.com/oauth/authorize',
-      clientId: 5893,
-      redirectUri: 'http://localhost:3000/login',
-      scope: 'read,activity:read,profile:read_all'
+      clientId: parseInt(process.env.STRAVA_CLIENT_ID || '0'),
+      redirectUri: 'http://localhost:3500/login',
+      scope: 'read,activity:read_all,profile:read_all'
     },
-    clientSecret: process.env.CLIENTSECRET || ''
+    clientSecret: process.env.STRAVA_CLIENT_SECRET || ''
   },
   mongo: {
     url: 'mongodb://localhost:27017/strava'

--- a/server/src/routes/api.ts
+++ b/server/src/routes/api.ts
@@ -57,6 +57,11 @@ export default function setupRoutes(app: Application): void {
     }
   });
 
+  apiRoutes.post('/logout', (req: Request, res: Response) => {
+    res.clearCookie('sessionId');
+    res.send({ loggedOut: true });
+  });
+
   apiRoutes.get('/loadActivities', async (req: AuthenticatedRequest, res: Response) => {
     try {
       if (!req.sessionData || !req.sessionData.sessionId) {

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -1,3 +1,4 @@
+import 'dotenv/config';
 import express, { Request, Response, NextFunction, Application } from 'express';
 import cookieParser from 'cookie-parser';
 import * as bodyParser from 'body-parser';
@@ -12,7 +13,13 @@ interface AppError extends Error {
 
 const app: Application = express();
 const server = http.createServer(app);
-const port = normalizePort(process.env.PORT || '3000');
+
+console.log('Environment PORT:', process.env.PORT);
+console.log('Environment STRAVA_CLIENT_ID:', process.env.STRAVA_CLIENT_ID);
+console.log('Environment STRAVA_CLIENT_SECRET:', process.env.STRAVA_CLIENT_SECRET ? 'SET' : 'NOT SET');
+console.log('Nodemon config updated - checking port again');
+
+const port = normalizePort(process.env.PORT || '3501');
 
 console.log('Server started on port', port);
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,10 +11,10 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
-    port: 3000,
+    port: 3500,
     proxy: {
       '/api': {
-        target: 'http://localhost:3001',
+        target: 'http://localhost:3501',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- Updated application ports from 3000/3001 to 3500/3501
- Moved Strava API credentials to secure .env file
- Enhanced OAuth scope to include private activities (`activity:read_all`)

## Changes Made
- **Frontend**: Changed port from 3000 to 3500 in `vite.config.ts`
- **Backend**: Changed port from 3001 to 3501 in `server.ts`
- **Security**: Moved client ID and secret to `.env` file (excluded from git)
- **OAuth**: Updated redirect URI and enhanced scope for private activities
- **Config**: Removed hardcoded PORT from `nodemon.json`
- **Feature**: Added `/logout` endpoint for easy re-authentication

## Test plan
- [ ] Verify frontend runs on http://localhost:3500
- [ ] Verify backend runs on port 3501
- [ ] Test Strava OAuth flow with new scope
- [ ] Confirm private activities are accessible after re-authentication
- [ ] Verify .env file is not committed to git

🤖 Generated with [Claude Code](https://claude.ai/code)